### PR TITLE
fix: Prettier and eslint-plugin-prettier compatibility issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,9 @@ module.exports = {
     ecmaFeatures: {},
   },
   settings: {
+    react: {
+      version: "detect",
+    },
     "import/parsers": {
       "@typescript-eslint/parser": [".ts", ".tsx"],
     },
@@ -231,7 +234,13 @@ module.exports = {
     ],
     "react/jsx-curly-brace-presence": ["error", "never"],
     "react/prop-types": "off",
-    "@typescript-eslint/prefer-nullish-coalescing": ["error"],
+    "@typescript-eslint/prefer-nullish-coalescing": [
+      "error",
+      {
+        ignoreConditionalTests: true,
+        ignoreMixedLogicalExpressions: true,
+      },
+    ],
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error",
     "perfectionist/sort-imports": "off",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.33.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
-    "eslint-plugin-unused-imports": "^3.0.0"
+    "eslint-plugin-unused-imports": "^3.0.0",
+    "prettier": "^3.0.3"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
@@ -39,7 +40,7 @@
   "main": "index.js",
   "peerDependencies": {
     "eslint": ">=6.0.0",
-    "typescript": ">=3.0.0"
+    "typescript": ">=3.7.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6713,6 +6713,11 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
+  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
+
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"


### PR DESCRIPTION
## Description

This PR adds prettier to the library in order to prevent user from installing `prettier` version incompatible with the `eslint-plugin-prettier` plugin. It also fixes some eslint rules.