### PR TITLE
fix: npm versioning issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-react-native-matipl01",
   "description": "eslint config for React Native projects",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": "Mateusz Łopaciński <lop.mateusz.2001@gmail.com>",
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.3",


### PR DESCRIPTION
## Description

There were unpublished versions of this package added mistakenly before. They prevented me from publishing the next version of this package with the current major number. I bumped the major version manually to skip these conflicting versions.
