### PR TITLE
chore: Change nodeLinker to pnpm to fix semantic-release missing deps

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
 yarnPath: .yarn/releases/yarn-4.1.1.cjs
+nodeLinker: pnpm

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@semantic-release/release-notes-generator": "^12.0.0",
     "@types/eslint": "^8.56.10",
     "babel-jest": "^29.7.0",
-    "conventional-changelog-angular": "^7.0.0",
     "eslint": "^9.1.0",
     "husky": "^9.0.11",
     "jest": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4643,7 +4643,6 @@ __metadata:
     "@typescript-eslint/parser": "npm:^7.7.0"
     "@typescript-eslint/types": "npm:^7.7.0"
     babel-jest: "npm:^29.7.0"
-    conventional-changelog-angular: "npm:^7.0.0"
     eslint: "npm:^9.1.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-import-resolver-typescript: "npm:^3.6.1"


### PR DESCRIPTION
## Description

This PR fixes missing deps issue while trying to deploy config to npm with semantic-release.


BREAKING CHANGE: The new eslint v9 version uses the new API that is not compatible with v8 and previous releases.